### PR TITLE
Migrate to Standard CMake format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ DartConfiguration.tcl
 invalidJson
 Debug
 jsonGen
+
+deps
+Build
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dep/rapidjson"]
-	path = dep/rapidjson
-	url = https://github.com/miloyip/rapidjson.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,38 +5,33 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
       - george-edison55-precise-backports
+      - boost-latest
     packages:
-      - g++-5
       - cmake
       - cmake-data
+      - g++-6
+      - libgtest-dev
+      - libboost1.55-all-dev
       - valgrind
 
 
 before_install:
-  - git submodule update --init --recursive
+  - git clone --recursive https://github.com/Grauniad/CMakeUtils.git
+  - cd CMakeUtils
+  - ./travis/installGTest.sh
+  - cd ..
+  - ./buildDeps.sh
 
 install:
   - pip install --user cpp-coveralls
-  - pip install --user urllib3[secure]
-  - export CXX="g++-5"
-  - export CC="gcc-5"
-  
+  - export CXX="g++-6"
+  - export CC="gcc-6"
+
 script: 
-  - g++-5 --version
-  - cmake --version
-  - mkdir Build
-  - cd Build 
-  - cmake ..
-  - make
+  - g++-6 --version
+  - ./buildFromDeps.sh
+  - cd Build
   - make test
   - ctest -T Memcheck
   - cd ..
-  - mkdir Coverage
-  - cd Coverage 
-  - cmake -DCMAKE_BUILD_TYPE=Coverage --build . ..
-  - make
-  - make test 
-  - cd ..
-
-after_success:
-  - coveralls -r . -b Coverage -e dep -e Build -e test --gcov gcov-5 --verbose 
+  - COVERALLS_FLAGS="" ./CMakeUtils/travis/doCoverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - george-edison55-precise-backports
       - boost-latest
     packages:
       - cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,3 +89,27 @@ install (
     FILES       ${FixedJSON_BINARY_DIR}/FixedJSONConfigVersion.cmake
     DESTINATION lib/cmake/FixedJSON
 )
+
+#
+# Finally export the Config which CMake will use
+# when looking for matching libraries to link against.
+#
+install (
+    FILES       FixedJSONConfig.cmake
+    DESTINATION lib/cmake/FixedJSON
+)
+
+#
+# Configure Coverage Build
+#
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,91 @@
-cmake_minimum_required(VERSION 3.1.0)
+#
+# Project Definition
+#
+cmake_minimum_required(VERSION 3.8.2)
 project(FixedJSON)
 
 #
+# Find dependencies
+#
+find_package(Boost REQUIRED)
+find_package(OSDevTools 0.1 REQUIRED)
+find_package(UtilTime 0.1 REQUIRED)
+find_package(DevToolsLog 0.1 REQUIRED)
+find_package(RapidJSON 1.1.0 REQUIRED)
+
+#
 # Build configuration for SimpleJSON itself...
-
-set(CMAKE_CXX_STANDARD 14)
-
-set(SOURCE_FILES
+#
+# Exported Library (libFixedJSON)
+#
+add_library(FixedJSON STATIC
         include/SimpleJSON.h
         include/SimpleJSON.hpp
         src/SimpleJSON.cpp)
 
-include_directories(dep/rapidjson/include dep/rapidjson/thirdparty/gtest/include include)
+target_link_libraries(FixedJSON PUBLIC
+    DevToolsLog::Log
+    OSDevTools::OSDevTools
+    UtilTime::Time
+    Boost::boost)
+target_compile_features(FixedJSON PUBLIC cxx_std_14)
 
-add_library(libFixedJSON STATIC ${SOURCE_FILES})
-
-add_executable(jsonGen src/jsonGen.cpp)
-target_link_libraries(jsonGen libFixedJSON)
+target_include_directories(FixedJSON PUBLIC
+    $<BUILD_INTERFACE:${FixedJSON_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:include>
+)
 
 #
-# The remaining is Test configuration
+# Test Configuration
 #
-
-# Valgrind variables must be set before import the ctest module...
-set( MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --track-origins=yes --freelist-vol=2000000000 --error-exitcode=1 --track-fds=yes --num-callers=50 --fullpath-after= --trace-children=yes --leak-check=full" )
-set( MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/valgrind_suppressions" )
-find_program( MEMORYCHECK_COMMAND valgrind )
-
-include(CTest)
-
-add_subdirectory(dep/rapidjson/thirdparty/gtest EXCLUDE_FROM_ALL)
-
-add_executable(jsonTests test/json.cpp)
-target_link_libraries(jsonTests libFixedJSON gtest)
-
-add_executable(jsonGenTests test/json_gen.cpp)
-target_link_libraries(jsonGenTests libFixedJSON gtest)
+find_package(GTest REQUIRED)
 
 add_executable(invalidJson test/invalidJson.cpp)
-target_link_libraries(invalidJson libFixedJSON gtest)
+target_link_libraries(invalidJson FixedJSON GTest::GTest)
+
+add_executable(json test/json.cpp)
+target_link_libraries(json FixedJSON GTest::GTest)
+
+add_executable(json_gen test/json_gen.cpp)
+target_link_libraries(json_gen FixedJSON GTest::GTest)
+
+#
+# NOTE: Valgrind must be configured *before* testing is imported
+#
+set(MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --track-origins=yes --freelist-vol=2000000000 --error-exitcode=1 --track-fds=yes --num-callers=50 --fullpath-after= --trace-children=yes --leak-check=full" )
+find_program(MEMORYCHECK_COMMAND valgrind )
+include (CTest)
 
 enable_testing()
-add_test(jsonTests jsonTests)
-add_test(jsonGenTests jsonGenTests)
+add_test(json json)
 add_test(invalidJson invalidJson)
+add_test(json_gen json_gen)
 
+#
+# Installation instructions
+#
+install(TARGETS FixedJSON EXPORT FixedJSONTargets
+    ARCHIVE  DESTINATION lib
+    INCLUDES DESTINATION include
+    PUBLIC_HEADER DESTINATION include
+)
 
-SET(CMAKE_CXX_FLAGS_COVERAGE
-    "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage"
-    CACHE STRING "Flags used by the C++ compiler during coverage builds."
-    FORCE )
-SET(CMAKE_C_FLAGS_COVERAGE
-    "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage"
-    CACHE STRING "Flags used by the C compiler during coverage builds."
-    FORCE )
-SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
-    ""
-    CACHE STRING "Flags used for linking binaries during coverage builds."
-    FORCE )
-SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
-    ""
-    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
-    FORCE )
-MARK_AS_ADVANCED(
-    CMAKE_CXX_FLAGS_COVERAGE
-    CMAKE_C_FLAGS_COVERAGE
-    CMAKE_EXE_LINKER_FLAGS_COVERAGE
-    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+install (EXPORT FixedJSONTargets
+    FILE         FixedJSONTargets.cmake
+    NAMESPACE    FixedJSON::
+    DESTINATION  lib/cmake/FixedJSON
+)
+
+#
+# Define our package version
+#
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("FixedJSONConfigVersion.cmake"
+    VERSION       0.1
+    COMPATIBILITY SameMajorVersion
+)
+install (
+    FILES       ${FixedJSON_BINARY_DIR}/FixedJSONConfigVersion.cmake
+    DESTINATION lib/cmake/FixedJSON
+)

--- a/FixedJSONConfig.cmake
+++ b/FixedJSONConfig.cmake
@@ -1,0 +1,4 @@
+# Pull in any dependencies we may need...
+include(CMakeFindDependencyMacro)
+# Bootstrap our config
+include("${CMAKE_CURRENT_LIST_DIR}/FixedJSONTargets.cmake")

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Grauniad/FixedJSONParserCPP.svg?branch=master)](https://travis-ci.org/Grauniad/FixedJSONParserCPP)
 [![Coverage Status](https://coveralls.io/repos/github/Grauniad/FixedJSONParserCPP/badge.svg?branch=master)](https://coveralls.io/github/Grauniad/FixedJSONParserCPP?branch=master)
+## Motivation
 
 ## Parse JSON Messages into native types:
 ```c++

--- a/buildDeps.sh
+++ b/buildDeps.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if [[ -e FixedJSONConfig.cmake ]]; then
+    echo "Building dependencies..."
+else
+    echo "This script should be run in the home directory of the project"
+    exit 1
+fi
+
+if [[ -e deps/NSTimestamps ]]; then
+    echo "Existing NSTimestamps directory, no need to clone"
+else
+    git clone https://github.com/Grauniad/NanoSecondTimestamps.git deps/NSTimestamps || exit 1
+fi
+
+if [[ -e deps/OSCPPTools ]]; then
+    echo "Existing OSCPPTools directory, no need to clone"
+else
+    git clone https://github.com/Grauniad/OSCPPTools.git deps/OSCPPTools || exit 1
+fi
+
+if [[ -e deps/DevToolsLog ]]; then
+    echo "Existing DevToolsLog directory, no need to clone"
+else
+    git clone https://github.com/Grauniad/LegacyLogger.git deps/DevToolsLog || exit 1
+fi
+
+if [[ -e deps/rapidjson ]]; then
+    echo "Existing rapidjson directory, no need to clone"
+else
+    git clone https://github.com/Tencent/rapidjson.git deps/rapidjson || exit 1
+fi
+
+DEPS_BUILD=$PWD/deps/build
+DEPS_CMAKE_DEPO=$PWD/deps/build/lib/cmake
+mkdir -p $DEPS_BUILD
+
+
+deps=(NSTimestamps OSCPPTools DevToolsLog rapidjson);
+for dep in ${deps[@]} ; do
+    mkdir -p deps/$dep/build
+
+    pushd deps/$dep || exit 1
+    git pull
+    pushd build || exit 1
+
+    cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH:PATH=$DEPS_CMAKE_DEPO" "-DCMAKE_INSTALL_PREFIX:PATH=$DEPS_BUILD" .. || exit 1
+    make -j 3 || exit 1
+    make install || exit 1
+
+    popd || exit 1
+    popd || exit 1
+    done
+exit 1

--- a/buildDeps.sh
+++ b/buildDeps.sh
@@ -50,5 +50,4 @@ for dep in ${deps[@]} ; do
 
     popd || exit 1
     popd || exit 1
-    done
-exit 1
+done

--- a/buildDeps.sh
+++ b/buildDeps.sh
@@ -42,8 +42,6 @@ for dep in ${deps[@]} ; do
 
     pushd deps/$dep || exit 1
     git pull
-    git submodule init
-    git submodule update
     pushd build || exit 1
 
     cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH:PATH=$DEPS_CMAKE_DEPO" "-DCMAKE_INSTALL_PREFIX:PATH=$DEPS_BUILD" .. || exit 1

--- a/buildDeps.sh
+++ b/buildDeps.sh
@@ -42,6 +42,8 @@ for dep in ${deps[@]} ; do
 
     pushd deps/$dep || exit 1
     git pull
+    git submodule init
+    git submodule update
     pushd build || exit 1
 
     cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH:PATH=$DEPS_CMAKE_DEPO" "-DCMAKE_INSTALL_PREFIX:PATH=$DEPS_BUILD" .. || exit 1

--- a/buildFromDeps.sh
+++ b/buildFromDeps.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DEPS_LOCATION="$PWD/deps/build/lib/cmake"
+if [[ -e $DEPS_LOCATION ]]; then
+    echo "Building project..."
+else
+    echo "Dependencies must be built first"
+    exit 1
+fi
+
+mkdir -p Build
+cd Build
+cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH:PATH=$DEPS_LOCATION" .. || exit 1
+make || exit 1
+cd ..


### PR DESCRIPTION
Migrate the CMake configuration to use the recomended CMake
configuration, allowing us to be easily built against by other CMake
projects.