### PR TITLE
Performance enhancements to the JSON Parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - make test
   - ctest -T Memcheck
   - cd ..
-  - COVERALLS_FLAGS="-e benchmarks/example_dom.cpp -e benchmarks/example_dom.cpp" ./CMakeUtils/travis/doCoverage.sh
+  - COVERALLS_FLAGS="-e benchmarks/example_dom.cpp -e benchmarks/glossary_dom.cpp" ./CMakeUtils/travis/doCoverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - make test
   - ctest -T Memcheck
   - cd ..
-  - COVERALLS_FLAGS="" ./CMakeUtils/travis/doCoverage.sh
+  - COVERALLS_FLAGS="-e benchmarks" ./CMakeUtils/travis/doCoverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - make test
   - ctest -T Memcheck
   - cd ..
-  - COVERALLS_FLAGS="-e benchmarks" ./CMakeUtils/travis/doCoverage.sh
+  - COVERALLS_FLAGS="-e benchmarks/example_dom.cpp -e benchmarks/example_dom.cpp" ./CMakeUtils/travis/doCoverage.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ target_include_directories(FixedJSON PUBLIC
     $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:include>
 )
+
+set_property(TARGET FixedJSON PROPERTY PUBLIC_HEADER
+    ${FixedJSON_SOURCE_DIR}/include/SimpleJSON.h
+    ${FixedJSON_SOURCE_DIR}/include/SimpleJSON.hpp
+)
 #
 # Generator
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,20 @@ target_include_directories(FixedJSON PUBLIC
     $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:include>
 )
+#
+# Generator
+#
+add_executable(jsonGen src/jsonGen.cpp)
+target_link_libraries(jsonGen FixedJSON UtilTime::Time)
+
+#
+# Benchmarks
+#
+add_executable(example_dom benchmarks/example_dom.cpp)
+target_link_libraries(example_dom FixedJSON UtilTime::Time)
+
+add_executable(glossary_dom benchmarks/glossary_dom.cpp)
+target_link_libraries(glossary_dom FixedJSON UtilTime::Time)
 
 #
 # Test Configuration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/Grauniad/FixedJSONParserCPP/badge.svg?branch=master)](https://coveralls.io/github/Grauniad/FixedJSONParserCPP?branch=master)
 ## Motivation
 
+### FixedJSON
+### Traditional DOM
+
 ## Parse JSON Messages into native types:
 ```c++
 /*

--- a/benchmarks/example_dom.cpp
+++ b/benchmarks/example_dom.cpp
@@ -1,0 +1,67 @@
+#include <SimpleJSON.h>
+#include <iostream>
+#include <util_time.h>
+
+using namespace std;
+using namespace nstimestamp;
+
+#include "rapidjson/document.h"
+using namespace rapidjson;
+
+namespace {
+    const size_t NUM_ITERATIONS = 1000000;
+    const char *json = "{\"project\":\"rapidjson\",\"stars\":10}";
+    NewStringField(project);
+    NewUIntField(stars);
+    using UserData = SimpleParsedJSON<project, stars>;
+}
+
+std::string Fixed() {
+    std::string error;
+    thread_local UserData data;
+    data.Clear();
+    if (data.Parse(json, error)) {
+        data.Get<stars>() += 1;
+        return data.GetJSONString();
+    } else {
+        return "";
+    }
+}
+
+std::string NativeRapidJSON() {
+    // 1. Parse a JSON string into DOM.
+    Document d;
+    d.Parse(json);
+
+    // 2. Modify it by DOM.
+    Value& s = d["stars"];
+    s.SetInt(s.GetInt() + 1);
+
+    // 3. Stringify the DOM
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+    d.Accept(writer);
+
+    // Output {"project":"rapidjson","stars":11}
+    return buffer.GetString();
+}
+
+int main(int argc, char **argv) {
+    Time start;
+    for (size_t i = 0; i< NUM_ITERATIONS; ++i) {
+        Fixed();
+    }
+    Time end;
+    long FIXED = end.DiffUSecs(start);
+    std::cout << "Fixed took: " << end.DiffUSecs(start) / (1.0*NUM_ITERATIONS) << "us/itter" << std::endl;
+
+    start.SetNow();
+    for (size_t i = 0; i< NUM_ITERATIONS; ++i) {
+        NativeRapidJSON();
+    }
+    end.SetNow();
+    long NATIVE = end.DiffUSecs(start);
+    std::cout << "Native took: " << end.DiffUSecs(start) / (1.0*NUM_ITERATIONS) << "us/itter" << std::endl;
+    std::cout << "Speedup: " << (100.0*(NATIVE - FIXED)) / (NATIVE) << "%" << std::endl;
+    return 0;
+}

--- a/benchmarks/glossary_dom.cpp
+++ b/benchmarks/glossary_dom.cpp
@@ -1,0 +1,148 @@
+#include <SimpleJSON.h>
+#include <iostream>
+#include <util_time.h>
+
+using namespace std;
+using namespace nstimestamp;
+
+#include "rapidjson/document.h"
+using namespace rapidjson;
+
+//namespace {
+    const size_t NUM_ITERATIONS = 1000;
+    const std::string JSON = R"JSON(
+        {
+            "glossary": {
+                "title": "example glossary",
+                "GlossDiv": {
+                    "title": "S",
+                    "GlossList": {
+                        "GlossEntry": {
+                            "ID": "SGML",
+                            "SortAs": "SGML",
+                            "GlossTerm": "Standard Generalized Markup Language",
+                            "Acronym": "SGML",
+                            "Abbrev": "ISO 8879:1986",
+                            "GlossDef": {
+                                "para": "A meta-markup language, used to create markup languages such as DocBook.",
+                                "GlossSeeAlso": ["GML", "XML"]
+                            },
+                            "GlossSee": "markup"
+                        }
+                    }
+                }
+            }
+        }
+    )JSON";
+
+    NewStringField(Abbrev);
+    NewStringField(Acronym);
+    NewStringArrayField(GlossSeeAlso);
+    NewStringField(para);
+    NewStringField(GlossSee);
+    NewStringField(GlossTerm);
+    NewStringField(ID);
+    NewStringField(SortAs);
+    NewStringField(title);
+
+    namespace GlossDef_fields {
+        typedef SimpleParsedJSON <GlossSeeAlso, para> JSON;
+    }
+    NewEmbededObject(GlossDef, GlossDef_fields::JSON);
+
+    namespace GlossEntry_fields {
+        typedef SimpleParsedJSON <
+        Abbrev,
+        Acronym,
+        GlossDef,
+        GlossSee,
+        GlossTerm,
+        ID,
+        SortAs
+        > JSON;
+    }
+    NewEmbededObject(GlossEntry, GlossEntry_fields::JSON);
+
+    namespace GlossList_fields {
+        typedef SimpleParsedJSON <
+        GlossEntry
+        > JSON;
+    }
+    NewEmbededObject(GlossList, GlossList_fields::JSON);
+
+    namespace GlossDiv_fields {
+            typedef SimpleParsedJSON <
+            GlossList,
+            title
+            > JSON;
+        }
+    NewEmbededObject(GlossDiv, GlossDiv_fields::JSON);
+
+    namespace glossary_fields {
+        typedef SimpleParsedJSON <
+        GlossDiv,
+        title
+        > JSON;
+    }
+    NewEmbededObject(glossary, glossary_fields::JSON);
+
+    typedef SimpleParsedJSON <glossary> OutputJSON;
+//}
+
+std::string Fixed(const char* json) {
+    std::string error;
+    thread_local OutputJSON data;
+    data.Clear();
+    auto& entry = data.Get<glossary>().Get<GlossDiv>().Get<GlossList>().Get<GlossEntry>();
+    if (data.Parse(json, error) && entry.Supplied<ID>()) {
+        return entry.Get<ID>();
+    } else {
+        return "";
+    }
+}
+
+std::string NativeRapidJSON(const char* json) {
+    std::string result = "";
+    Document d;
+    d.Parse(json);
+
+    auto glossIt = d.FindMember("glossary");
+    if (glossIt != d.MemberEnd() && glossIt->value.IsObject()) {
+        auto GlossDivIt = glossIt->value.FindMember("GlossDivIt");
+        if (GlossDivIt != glossIt->value.MemberEnd() && GlossDivIt->value.IsObject()) {
+            auto GlossList = GlossDivIt->value.FindMember("GlossList");
+            if (GlossList != GlossDivIt->value.MemberEnd() && GlossList->value.IsObject()) {
+                auto GlossEntry = GlossList->value.FindMember("GlossEntry");
+                if (GlossEntry != GlossList->value.MemberEnd() && GlossEntry->value.IsObject()) {
+                    auto idIt = GlossEntry->value.FindMember("ID");
+                    if (idIt != GlossEntry->value.MemberEnd() && idIt->value.IsString()) {
+                        return idIt->value.GetString();
+                    }
+                }
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    Fixed(JSON.c_str());
+    NativeRapidJSON(JSON.c_str());
+    Time start;
+    for (size_t i = 0; i< NUM_ITERATIONS; ++i) {
+        NativeRapidJSON(JSON.c_str());
+    }
+    Time end;
+    long NATIVE = end.DiffUSecs(start);
+    std::cout << "Native took: " << end.DiffUSecs(start) / (1.0*NUM_ITERATIONS) << "us/itter" << std::endl;
+
+    start.SetNow();
+    for (size_t i = 0; i< NUM_ITERATIONS; ++i) {
+        Fixed(JSON.c_str());
+    }
+    end.SetNow();
+    long FIXED = end.DiffUSecs(start);
+    std::cout << "Fixed took: " << end.DiffUSecs(start) / (1.0*NUM_ITERATIONS) << "us/itter" << std::endl;
+
+    std::cout << "Speedup: " << (100.0*(NATIVE - FIXED)) / (NATIVE) << "%" << std::endl;
+    return 0;
+}

--- a/benchmarks/glossary_dom.cpp
+++ b/benchmarks/glossary_dom.cpp
@@ -122,6 +122,8 @@ std::string NativeRapidJSON(const char* json) {
             }
         }
     }
+
+    return "";
 }
 
 int main(int argc, char **argv) {

--- a/buildDeps.sh
+++ b/buildDeps.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+DEPS_BUILD=$PWD/deps/build
+if [[ "$1" == "" ]]; then
+    echo "No install directory provided, falling back to: $DEPS_BUILD"
+else
+    DEPS_BUILD=$1
+fi
+
+DEPS_CMAKE_DEPO=$DEPS_BUILD/lib/cmake
+mkdir -p $DEPS_BUILD
+
 if [[ -e FixedJSONConfig.cmake ]]; then
     echo "Building dependencies..."
 else
@@ -30,10 +40,6 @@ if [[ -e deps/rapidjson ]]; then
 else
     git clone https://github.com/Tencent/rapidjson.git deps/rapidjson || exit 1
 fi
-
-DEPS_BUILD=$PWD/deps/build
-DEPS_CMAKE_DEPO=$PWD/deps/build/lib/cmake
-mkdir -p $DEPS_BUILD
 
 
 deps=(NSTimestamps OSCPPTools DevToolsLog rapidjson);

--- a/include/SimpleJSON.hpp
+++ b/include/SimpleJSON.hpp
@@ -769,7 +769,6 @@ template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Parse(const char* json, std::string& errMsg) {
     class RapidJSONParser: public IParser {
         virtual void Parse(const char* json, SimpleParsedJSON<Fields...>& spj) {
-            bool ok = true;
             rapidjson::StringStream ss(json);
             rapidjson::Reader reader;
             rapidjson::ParseResult result = reader.Parse(ss,spj);

--- a/include/SimpleJSON.hpp
+++ b/include/SimpleJSON.hpp
@@ -156,7 +156,7 @@ struct StringField: public FieldBase {
 
     virtual void Clear() {
         FieldBase::Clear();
-        value = "";
+        value.clear();
     }
 
     bool String(const char* str, rapidjson::SizeType length, bool copy) {
@@ -480,10 +480,22 @@ struct EmbededObjectField: public FieldBase {
 
         return true;
     }
-    bool StartObject() {
-        ++depth;
-        value.StartObject();
-        return true;
+    FieldBase* StartObject() override {
+        FieldBase* current = nullptr;
+
+        if (depth == 0) {
+            depth = 1;
+            value.StartObject();
+            current = this;
+        } else if (depth == 1) {
+            ++depth;
+            current = value.GetCurrentField()->StartObject();
+        } else {
+            // TODO - obviously this rearchitecture needs some cleaning up
+            //        once the basic wiring is working
+            throw spJSON::ParseError();
+        }
+        return current;
     }
 
     bool EndObject(rapidjson::SizeType memberCount) {
@@ -611,16 +623,24 @@ struct ObjectArray: public FieldBase {
      *     Rapid JSON Interface
      *******************************/ 
 
-    bool StartObject() {
-        if (depth > 0) {
-            ++depth;
-            value.back()->StartObject();
-        } else {
+    FieldBase* StartObject() {
+        FieldBase* activeObject = nullptr;
+
+        // TODO: EWWWWW! So much EWWW! We need to make this not a performance killer
+        if (depth == 0) {
             depth = 1;
             value.emplace_back();
             value.back()->StartObject();
+            activeObject = this;
+        } else if (depth == 1) {
+            // TODO: Although it seems counter-intuative, we haven't increased the depth
+            //       The reason is that by returning the child's active object all
+            //       calls (including the EndObject) will by-pass the array
+            activeObject = value.back()->GetCurrentField()->StartObject();
+        } else {
+            throw spJSON::ParseError{};
         }
-        return true;
+        return activeObject;
     }
 
     bool Null() {
@@ -789,9 +809,8 @@ void SimpleParsedJSON<Fields...>::Clear() {
     depth = 0;
     currentField = nullptr;
     isArray = false;
-    for (auto& item: fieldMap) {
-        item.second.field->Clear();
-    }
+    fastFields.Clear();
+    objectStack.clear();
 }
 
 template <class...Fields>
@@ -819,12 +838,8 @@ bool SimpleParsedJSON<Fields...>::StartObject() {
     if ( depth == 0) {
         ++depth;
     } else {
-        if ( currentField != nullptr) {
-            ++depth;
-            currentField->field->StartObject();
-        } else {
-            throw spJSON::UnknownTypeError();
-        }
+        ++depth;
+        objectStack.push_back(GetCurrentField()->StartObject());
     }
     return true;
 }
@@ -837,8 +852,9 @@ template <class...Fields>
 bool SimpleParsedJSON<Fields...>::EndObject(rapidjson::SizeType memberCount) {
     if ( depth == 1) {
         --depth;
-    } else if (depth > 1 && currentField) {
-        currentField->field->EndObject(memberCount);
+    } else if (depth > 1 && objectStack.empty() == false) {
+        objectStack.back()->EndObject(memberCount);
+        objectStack.pop_back();
         --depth;
     } else {
         throw spJSON::ParseError();
@@ -859,10 +875,10 @@ bool SimpleParsedJSON<Fields...>::Key(
     rapidjson::SizeType length,
     bool copy)
 {
-    if (currentField && depth > 1 ) {
-        currentField->field->Key(str,length,copy);
+    if (objectStack.size() > 0) {
+        objectStack.back()->Key(str,length,copy);
     } else {
-        currentField = Get(str);
+        currentField = Get(str, length);
 
         if (!currentField) {
             throw spJSON::UnknownFieldError {str} ;
@@ -890,11 +906,7 @@ bool SimpleParsedJSON<Fields...>::String(
     rapidjson::SizeType length,
     bool copy)
 {
-    if (currentField) {
-        currentField->field->String(str,length,copy);
-    } else {
-        throw spJSON::ParseError();
-    }
+    GetCurrentField()->String(str, length, copy);
 
     return true;
 }
@@ -911,22 +923,13 @@ bool SimpleParsedJSON<Fields...>::RawNumber(const char *str, size_t len, bool co
  */
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Int(int i) {
-    if (currentField) {
-        currentField->field->Int(i);
-    } else {
-        throw spJSON::ParseError();
-    }
+    GetCurrentField()->Int(i);
     return true;
 }
 
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Int64(int64_t i) {
-    if (currentField) {
-        currentField->field->Int64(i);
-    } else {
-        throw spJSON::ParseError();
-    }
-
+    GetCurrentField()->Int64(i);
     return true;
 }
 
@@ -939,22 +942,13 @@ bool SimpleParsedJSON<Fields...>::Int64(int64_t i) {
  */
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Uint(unsigned u) {
-    if (currentField) {
-        currentField->field->Uint(u);
-    } else {
-        throw spJSON::ParseError();
-    }
+    GetCurrentField()->Uint(u);
     return true;
 }
 
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Uint64(uint64_t u) {
-    if (currentField) {
-        currentField->field->Uint64(u);
-    } else {
-        throw spJSON::ParseError();
-    }
-
+    GetCurrentField()->Uint64(u);
     return true;
 }
 
@@ -966,11 +960,7 @@ bool SimpleParsedJSON<Fields...>::Uint64(uint64_t u) {
  */
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Double(double d) {
-    if (currentField) {
-        currentField->field->Double(d);
-    } else {
-        throw spJSON::ParseError();
-    }
+    GetCurrentField()->Double(d);
     return true;
 }
 
@@ -981,33 +971,19 @@ bool SimpleParsedJSON<Fields...>::Double(double d) {
  */
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Bool(bool b) {
-    if (currentField) {
-        currentField->field->Bool(b);
-    } else {
-        throw spJSON::ParseError();
-    }
+    GetCurrentField()->Bool(b);
     return true;
 }
 
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::StartArray() {
-    if (currentField) {
-        currentField->field->StartArray();
-    } else {
-        throw spJSON::ParseError();
-    }
-
+    GetCurrentField()->StartArray();
     return true;
 }
 
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::EndArray(rapidjson::SizeType elementCount) {
-    if (currentField) {
-        currentField->field->EndArray(elementCount);
-    } else {
-        throw spJSON::ParseError();
-    }
-
+    GetCurrentField()->EndArray(elementCount);
     return true;
 }
 
@@ -1016,12 +992,7 @@ bool SimpleParsedJSON<Fields...>::EndArray(rapidjson::SizeType elementCount) {
  *****************************************************************************/
 template <class...Fields>
 bool SimpleParsedJSON<Fields...>::Null() {
-    if (currentField) {
-        currentField->field->Null();
-    } else {
-        throw spJSON::ParseError();
-    }
-
+    GetCurrentField()->Null();
     return true;
 }
 
@@ -1032,11 +1003,7 @@ template <class...Fields>
 template <int idx>
 void SimpleParsedJSON<Fields...>::AddField() {
     auto& field = std::get<idx>(fields);
-    typename FieldMap::value_type item(
-            field.Name(),
-            { &field, field.Name() }
-        );
-    fieldMap.insert(std::move(item));
+    fastFields.Put(&field);
 }
 
 template<class ...Fields>
@@ -1145,12 +1112,18 @@ inline void SimpleParsedJSON<Fields...>::PrintField(Builder& builder, bool nullI
 
 template <class...Fields>
 typename SimpleParsedJSON<Fields...>::FieldInfo*
-SimpleParsedJSON<Fields...>::Get(const char* fieldName)  {
-    auto it = fieldMap.find(fieldName);
-    if ( it != fieldMap.end()) {
-        return &it->second;
+SimpleParsedJSON<Fields...>::Get(const char* fieldName, const size_t& len)  {
+    return fastFields.Get(fieldName, len);
+}
+
+template <class...Fields>
+FieldBase *SimpleParsedJSON<Fields...>::GetCurrentField() {
+    if (objectStack.size() > 0) {
+        return objectStack.back();
+    } else if (currentField) {
+        return currentField->field;
     } else {
-        return nullptr;
+        throw spJSON::ParseError{};
     }
 }
 

--- a/src/SimpleJSON.cpp
+++ b/src/SimpleJSON.cpp
@@ -46,7 +46,7 @@ void FieldBase::Clear() {
     supplied = false;
 }
 
-bool FieldBase::StartObject() {
+FieldBase * FieldBase::StartObject() {
    throw spJSON::WrongTypeError{Name()};
 }
 
@@ -219,7 +219,7 @@ private:
                 , name(name)
         {
             string childNamespace = name + "_fields";
-            objDefn = std::make_unique<SimpleParsedJSON_Generator>(
+            objDefn = std::make_shared<SimpleParsedJSON_Generator>(
                         childNamespace,
                         indent + "    ",
                         options);

--- a/src/SimpleJSON.cpp
+++ b/src/SimpleJSON.cpp
@@ -255,9 +255,9 @@ private:
         }
 
     public:
+        bool isArray;
         std::string indent;
         std::string name;
-        bool isArray;
         shared_ptr<SimpleParsedJSON_Generator> objDefn;
     };
 public:
@@ -509,7 +509,6 @@ public:
     }
 
     bool Null() {
-        auto &active = ActiveObject();
         if (options.ignoreNull == false) {
             throw "TODO!";
         } else {


### PR DESCRIPTION
Various performance enhancements have been made to the parsing of
 JSON objects (although further work is required to handle arrays of
 embedded objects)

  - When handling embedded objects keep a pointer to the current depth.
    This prevents the need to recurse through each layer's JSON object
  - Faster key lookup (avoid use of std::map)
  - New benchmark binaries compare performance against the native
    rapid-json DOM

The Library will now outperform (~25%) the rapidJSON dom for simple objects
(see example_dom), but is still significantly slower (~40%) when there are
several layers of embedded objects (see glossary_dom). The biggest cost
here is our Reset() - but further investigation would be required to
close the gap. It is worth noting that glossary_dom is comprised
entirely of strings, meaning we do not currently gain anything from our
pre-allocated memory (each field must be strcpy'd onto the heap...)

Improving arrays of objects requires further work. The issue is that
each new object added to the array require a new JSON object to be
allocated and initialised. This is crippling for performance.